### PR TITLE
Simple timing script

### DIFF
--- a/simple_speed_test.py
+++ b/simple_speed_test.py
@@ -18,7 +18,7 @@ for patch_size in patch_sizes:
             # torch.cuda.synchronize()
             t1 = time.perf_counter()
             run_times.append((t1 - t0)/batch_size)
-        print('[Batchsize: {}, patch size: {}] '
+        print('[batch size: {}, patch size: {}] '
               'Time per patch: {:.4f} +- {:.4f} seconds'.
             format(batch_size,
                    patch_size,


### PR DESCRIPTION
hey @qiminchen : I think you were measuring runtime way too complicated. Check out this script for how you can set it up. You can use this one if you like. Just add a sweep over nets and over devices. (I don't have a GPU on my laptop so couldn't test it).

What I'm interested is in the _forward runtime for 1 patch_, not forward runtime for an image. This scripts gives
```
[Batchsize: 1, patch size: 168] Time per patch: 0.1443 +- 0.0069 seconds
[Batchsize: 10, patch size: 168] Time per patch: 0.0576 +- 0.0014 seconds
[Batchsize: 25, patch size: 168] Time per patch: 0.0557 +- 0.0021 seconds
[Batchsize: 1, patch size: 224] Time per patch: 0.1759 +- 0.0096 seconds
[Batchsize: 10, patch size: 224] Time per patch: 0.0997 +- 0.0029 seconds
[Batchsize: 25, patch size: 224] Time per patch: 0.1046 +- 0.0034 seconds
```
So basically, we get 30-60% boost when using the larger batch-size. Not 10x that you saw. The returns don't increase as we increase the batch size to 25.
 