### PR TITLE
Simple speed test

### DIFF
--- a/simple_speed_test.py
+++ b/simple_speed_test.py
@@ -2,26 +2,49 @@ import torch
 import time
 import numpy as np
 from models.efficientnet import efficientnet
+from models.vgg import vgg
+import torch.nn as nn
+from models.resnet import resnet
 
 
-model = efficientnet(False, 'b0', 1000, False, 1280)
+vgg16 = vgg(False, 'vgg16', 1000, False)
+vgg16.classifier = nn.Sequential(*list(vgg16.classifier.children())[:-1])
+resnet50 = resnet(False, 'resnet50', 1000, False)
+resnet50 = nn.Sequential(*list(resnet50.children())[:-1])
+resnet101 = resnet(False, 'resnet101', 1000, False)
+resnet101 = nn.Sequential(*list(resnet101.children())[:-1])
+
+models = {
+    'efficientnetb0': efficientnet(False, 'b0', 1000, False, 1280),
+    'efficientnetb1': efficientnet(False, 'b1', 1000, False, 1280),
+    'efficientnetb4': efficientnet(False, 'b4', 1000, False, 1280),
+    'vgg16': vgg16,
+    'resnet50': resnet50,
+    'resnet101': resnet101
+}
 
 batch_sizes = [1, 10, 25]
 patch_sizes = [168, 224]
 devices = ['cpu', 'cuda']
-for dev in devices:
-    device = torch.device(dev)
-    model = model.to(device)
-    for patch_size in patch_sizes:
-        for batch_size in batch_sizes:
-            run_times = []
-            for _ in range(10):
-                patch = torch.rand(batch_size, 3, patch_size, patch_size).to(device)
-                t0 = time.perf_counter()
-                res = model.extract_features(patch)
-                if device == 'cuda':
-                    torch.cuda.synchronize()
-                t1 = time.perf_counter()
-                run_times.append((t1 - t0)/batch_size)
-            print('[patch size: {}, batch size: {}, device: {}] Time per patch: {:.4f} ± {:.4f} seconds'.format(
-                patch_size, batch_size, device, np.mean(run_times), np.std(run_times)))
+for key, model in models.items():
+    print('==> model: {}'.format(key))
+    for dev in devices:
+        device = torch.device(dev)
+        model = model.to(device)
+        for patch_size in patch_sizes:
+            for batch_size in batch_sizes:
+                run_times = []
+                for _ in range(10):
+                    patch = torch.rand(batch_size, 3, patch_size, patch_size).to(device)
+                    t0 = time.perf_counter()
+                    if key.startswith('efficientnet'):
+                        res = model.extract_features(patch)
+                    else:
+                        res = model(patch).squeeze(-1).squeeze(-1)
+                    if dev == 'cuda':
+                        torch.cuda.synchronize()
+                    t1 = time.perf_counter()
+                    run_times.append((t1 - t0)/batch_size)
+                decimal = 4 if dev == 'cpu' else 8
+                print('[device: {}, patch size: {}, batch size: {}] Time per patch: {} ± {} seconds'.format(dev,
+                      patch_size, batch_size, np.round(np.mean(run_times), decimal), np.round(np.std(run_times), decimal)))


### PR DESCRIPTION
@beijbom hey Oscar, I added the GPU testing code, pretty simple and straightforward, the script gives

<pre>[patch size: 168, batch size: 1, device: cpu] Time per patch: 0.0424 ± 0.0049 seconds
[patch size: 168, batch size: 10, device: cpu] Time per patch: 0.0135 ± 0.0005 seconds
[patch size: 168, batch size: 25, device: cpu] Time per patch: 0.0143 ± 0.0003 seconds
[patch size: 224, batch size: 1, device: cpu] Time per patch: 0.0477 ± 0.0027 seconds
[patch size: 224, batch size: 10, device: cpu] Time per patch: 0.0241 ± 0.0002 seconds
[patch size: 224, batch size: 25, device: cpu] Time per patch: 0.0272 ± 0.0002 seconds

[patch size: 168, batch size: 1, device: cuda] Time per patch: 0.0272 ± 0.0566 seconds
[patch size: 168, batch size: 10, device: cuda] Time per patch: 0.0008 ± 0.0000 seconds
[patch size: 168, batch size: 25, device: cuda] Time per patch: 0.0003 ± 0.0000 seconds
[patch size: 224, batch size: 1, device: cuda] Time per patch: 0.0084 ± 0.0000 seconds
[patch size: 224, batch size: 10, device: cuda] Time per patch: 0.0008 ± 0.0000 seconds
[patch size: 224, batch size: 25, device: cuda] Time per patch: 0.0004 ± 0.0000 seconds</pre>

Does this look reasonable to you? Basically we get 40-70% boost when increasing the batch size but don't increase as increasing to 25 on CPU.